### PR TITLE
Add icon splash screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ node_modules
 android
 www/**
 resources/**
+icons/
 ios
 !.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ coverage
 node_modules
 android
 www/**
+resources/**
 ios
 !.gitkeep

--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ export function forwardNativeAppLinks() {
 }
 ```
 
+### App Icons and Splash Screens
+Are managed by `@capacitor/assets`. [Docs for the assets tool are here.](https://capacitorjs.com/docs/guides/splash-screens-and-icons)
+Assests for icons and Splash Screens go into the `/resources` dir.
+To add an App Icon set `resources/icon-only.png` & then `npm run generate-app-icons`
+
 ## Usage
 Bedrock Native Wallet uses [Capacitor.js](https://capacitorjs.com/docs/) for the native app.
 Capacitor has a large number of commands that can be used.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ export function forwardNativeAppLinks() {
 
 ### App Icons and Splash Screens
 Are managed by `@capacitor/assets`. [Docs for the assets tool are here.](https://capacitorjs.com/docs/guides/splash-screens-and-icons)
+
 Assests for icons and Splash Screens go into the `/resources` dir.
+
 To add an App Icon set `resources/icon-only.png` & then `npm run generate-app-icons`
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "create-capacitor-config": "source ./native-app-config.sh && ./scripts/set-capacitor-config.sh",
     "set-app-manifests": "source ./native-app-config.sh && ./scripts/set-native-app-manifests.sh",
-    "set-build-env": "source ./scripts/setup-build-env.sh"
+    "set-build-env": "source ./scripts/setup-build-env.sh",
+    "generate-app-icons": "npx capacitor-assets generate"
   },
   "repository": {
     "type": "git",
@@ -28,5 +29,8 @@
     "name": "Digital Bazaar, Inc.",
     "email": "support@digitalbazaar.com",
     "url": "https://digitalbazaar.com/"
+  },
+  "devDependencies": {
+    "@capacitor/assets": "^2.0.4"
   }
 }


### PR DESCRIPTION
Adds support for icons and splash screens for apps.

Features:
1. Adds a new capacitor cli tool for adding icons and splash screens to apps
2. ignores new dirs created for icon and splash screen caches
3. adds a new command for creating icons
4. adds a README section in Setup for adding icons and splash screens